### PR TITLE
chore(docker): configure huggingface cache directory for django-user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
-# Create a non-root user for security
-RUN groupadd -r django-user && useradd -r -g django-user django-user
+# Create a non-root user for security with home directory for model cache
+RUN groupadd -r django-user && useradd -r -g django-user -m django-user
+
+# Set HuggingFace cache directory
+ENV HF_HOME=/home/django-user/.cache/huggingface \
+    TRANSFORMERS_CACHE=/home/django-user/.cache/huggingface
 
 WORKDIR /app
 


### PR DESCRIPTION
- Add home directory creation flag (-m) to django-user to enable model caching
- Set HF_HOME environment variable to /home/django-user/.cache/huggingface
- Set TRANSFORMERS_CACHE environment variable for model downloads
- Ensures non-root user can properly cache downloaded models and transformers